### PR TITLE
Inject a script into every page that records userland performance metrics

### DIFF
--- a/internal/devtools.py
+++ b/internal/devtools.py
@@ -5,6 +5,7 @@
 """Main entry point for interfacing with Chrome's remote debugging protocol"""
 import base64
 import gzip
+import io
 import logging
 import multiprocessing
 import os
@@ -76,6 +77,7 @@ class DevTools(object):
         self.html_body = False
         self.all_bodies = False
         self.request_sequence = 0
+        self.script_dir = os.path.join(os.path.abspath(os.path.dirname(__file__)), 'js')
 
     def prepare(self):
         """Set up the various paths and states"""
@@ -241,6 +243,10 @@ class DevTools(object):
         self.send_command('Debugger.enable', {})
         self.send_command('ServiceWorker.enable', {})
         self.enable_target()
+        performance_metrics_script = os.path.join(self.script_dir, 'performance_metrics.js')
+        if os.path.isfile(performance_metrics_script):
+            with io.open(performance_metrics_script, 'r', encoding='utf-8') as script_file:
+                self.send_command('Page.addScriptToEvaluateOnNewDocument', {'source': script_file.read()})
         if len(self.workers):
             for target in self.workers:
                 self.enable_target(target['targetId'])

--- a/internal/js/performance_metrics.js
+++ b/internal/js/performance_metrics.js
@@ -1,0 +1,19 @@
+(function() {
+    window.__SPEEDCURVE__ = window.__SPEEDCURVE__ || {};
+    window.__SPEEDCURVE__.performanceEntries = [];
+
+    const observer = new PerformanceObserver((list) => {
+        list.getEntries().forEach((entry) => {
+            window.__SPEEDCURVE__.performanceEntries.push(entry)
+        });
+    });
+
+    observer.observe({ type: "longtask", buffered: true });
+    observer.observe({ type: "largest-contentful-paint", buffered: true });
+    observer.observe({ type: "element", buffered: true });
+    observer.observe({ type: "paint", buffered: true });
+
+    // Disabled layout shifts for now, since the resulting entries are potentially
+    // very large.
+    // observer.observe({ type: "layout-shift", buffered: true });
+})();


### PR DESCRIPTION
I distrust wptagent's method of extracting performance metrics via DevTools events. They're a bit messy and we've had bugs in the past where the events are attributed to the wrong frame. This PR is my attempt at switching to a more "standard" way of gathering performance metrics, which is to use the userland JavaScript APIs.

What this PR does is inject a script into every page that creates a `PerformanceObserver` and collects a bunch of metrics into a global variable.

### Upsides

- The values are exactly what tools like LUX or Lighthouse would report.
- The code is way easier to understand than the DevTools event processing.

### Downsides

- The test result data size is increased. In fact, I've opted not to include layout shifts in this PR because they create a lot of data.
- It's a bit trickier to do things like make the metrics relative to the beginning of a script step, as opposed to relative to navigationStart.