### PR TITLE
Disable ChromeWhatsNewUI, block requests to optimizationguide-pa.googleapis.com

### DIFF
--- a/internal/chrome_desktop.py
+++ b/internal/chrome_desktop.py
@@ -46,7 +46,8 @@ HOST_RULES = [
     '"MAP cache.pack.google.com 127.0.0.1"',
     '"MAP clients1.google.com 127.0.0.1"',
     '"MAP redirector.gvt1.com 127.0.0.1"',
-    '"MAP laptop-updates.brave.com 127.0.0.1"'
+    '"MAP laptop-updates.brave.com 127.0.0.1"',
+    '"MAP optimizationguide-pa.googleapis.com 127.0.0.1"'
 ]
 
 ENABLE_CHROME_FEATURES = [
@@ -57,7 +58,8 @@ ENABLE_CHROME_FEATURES = [
 
 DISABLE_CHROME_FEATURES = [
     'InterestFeedContentSuggestions',
-    'CalculateNativeWinOcclusion'
+    'CalculateNativeWinOcclusion',
+    'ChromeWhatsNewUI'
 ]
 
 ENABLE_BLINK_FEATURES = [


### PR DESCRIPTION
What's new UI splash screen was introduced in Chrome 98

Some customers are seeing requests to optimizationguide-pa.googleapis.com and it's adding 250KB to their page size