### PR TITLE
Disable Chrome features to reduce network contention during tests

### DIFF
--- a/internal/chrome_desktop.py
+++ b/internal/chrome_desktop.py
@@ -46,8 +46,9 @@ HOST_RULES = [
     '"MAP cache.pack.google.com 127.0.0.1"',
     '"MAP clients1.google.com 127.0.0.1"',
     '"MAP redirector.gvt1.com 127.0.0.1"',
-    '"MAP laptop-updates.brave.com 127.0.0.1"',
-    '"MAP optimizationguide-pa.googleapis.com 127.0.0.1"'
+    '"MAP optimizationguide-pa.googleapis.com 127.0.0.1"',
+    '"MAP offlinepages-pa.googleapis.com 127.0.0.1"',
+    '"MAP update.googleapis.com 127.0.0.1"'
 ]
 
 ENABLE_CHROME_FEATURES = [
@@ -59,7 +60,8 @@ ENABLE_CHROME_FEATURES = [
 DISABLE_CHROME_FEATURES = [
     'InterestFeedContentSuggestions',
     'CalculateNativeWinOcclusion',
-    'ChromeWhatsNewUI'
+    'ChromeWhatsNewUI',
+    'OfflinePagesPrefetching'
 ]
 
 ENABLE_BLINK_FEATURES = [


### PR DESCRIPTION
Remove Brave updates URL

Map offlinepages-pa.googleapis.com and update.googleapis.com to 127.0.0.1

Disable prefetching of offline pages