### PR TITLE
Added some more debugging

### DIFF
--- a/internal/devtools_browser.py
+++ b/internal/devtools_browser.py
@@ -133,6 +133,8 @@ class DevtoolsBrowser(object):
             if not self.options.android and 'throttle_cpu' in self.job and\
                     (not task['running_lighthouse'] or not self.job['lighthouse_config']):
                 logging.debug('DevTools CPU Throttle target: %0.3fx', self.job['throttle_cpu'])
+                logging.debug('cpu_scale_multiplier: %0.3f, throttle_cpu_requested %0.3f, throttle_cpu: %0.3f', 
+                    self.job['cpu_scale_multiplier'], self.job['throttle_cpu_requested'], self.job['throttle_cpu'])
                 if self.job['throttle_cpu'] > 1:
                     self.devtools.send_command("Emulation.setCPUThrottlingRate",
                                                 {"rate": self.job['throttle_cpu']},

--- a/internal/webpagetest.py
+++ b/internal/webpagetest.py
@@ -489,6 +489,7 @@ class WebPageTest(object):
                             throttle *= self.cpu_scale_multiplier
                         job['throttle_cpu_requested'] = job['throttle_cpu']
                         job['throttle_cpu'] = throttle
+                        job['cpu_scale_multiplier'] = self.cpu_scale_multiplier # Ugly hack to make it available later (AD)
                         logging.debug('cpu_scale_multiplier: %0.3f, throttle_cpu_requested %0.3f, throttle_cpu: %0.3f', 
                             self.cpu_scale_multiplier, job['throttle_cpu_requested'], job['throttle_cpu'])
 


### PR DESCRIPTION
Early debug messages from /internal/webpagetest.py don't get included in the debug log as the log is created later so moving logging statements around