### PR TITLE
Update Netlog processing

### DIFF
--- a/internal/chrome_desktop.py
+++ b/internal/chrome_desktop.py
@@ -94,6 +94,7 @@ DISABLE_CHROME_FEATURES = [
     'AutofillServerCommunication',
     'CalculateNativeWinOcclusion',
     'ChromeWhatsNewUI',
+    'HeavyAdPrivacyMitigations',
     'InterestFeedContentSuggestions',
     'MediaRouter',
     'OfflinePagesPrefetching',
@@ -164,6 +165,7 @@ class ChromeDesktop(DesktopBrowser, DevtoolsBrowser):
                 logging.exception('Error creating pipe for NetLog')
 
         # If we need to keep the netlog create file to write it to
+        # TODO (AD) Stop doing this for lighthouse runs
         if 'netlog' in job and job['netlog']:
             self.netlog_file = os.path.join(task['dir'], task['prefix']) + '_netlog.txt'
             self.netlog_out = open(self.netlog_file, 'wb')

--- a/internal/support/devtools_parser.py
+++ b/internal/support/devtools_parser.py
@@ -1088,6 +1088,8 @@ class DevToolsParser(object):
                 user_timing_events.sort(key=lambda x: x['ts'] if 'ts' in x else 0)
             main_frames = []
             navigation_start = None
+
+# TODO (AD) Why isnt LCP (or LargestTextPaint / LargestImagePaint) in this list? 
             names = [
                 'firstLayout',
                 'firstPaint',

--- a/internal/support/netlog_parser.py
+++ b/internal/support/netlog_parser.py
@@ -477,18 +477,18 @@ class NetLogParser():
 
 
                 # Remove any Chrome internal requests that happen before the main request
+                # What would happen to requests such as OCSP ones (does Chrome make these anymore?)
                 # Would be better to actually prevent these requests with Chrome flags
-                found1stRequest = False
-                requestsToRemove = []
+                found_1st_request = False
+                requests_to_remove = []
                 for index, request in enumerate(requests):
-                    if found1stRequest == False and \
+                    if found_1st_request == False and \
                         'initiator' in request and request['initiator'] == 'not an origin':
-                        print(index, request)
-                        requestsToRemove.append(index)
+                        requests_to_remove.append(index)
                     else:
                         found1stRequest = True
-                for toRemove in requestsToRemove:
-                    requests.pop(toRemove)
+                for to_remove in requests_to_remove:
+                    requests.pop(to_remove)
 
                 # Find the start timestamp if we didn't have one already
                 times = ['dns_start', 'dns_end',


### PR DESCRIPTION
- Disable HeavyAdPrivacyMitigation
- Only use the times from the first request to calculate start time

A bit unsure whether the last change will mean we miss something but it will stop later requests to Google (where the browser has made a connection for Chrome's internal purposes and so has a DNS start / end tripping us up)