### PR TITLE
Change netlog start time calculation to exclude later requests

### DIFF
--- a/internal/support/netlog_parser.py
+++ b/internal/support/netlog_parser.py
@@ -496,6 +496,10 @@ class NetLogParser():
                          'ssl_start', 'ssl_end',
                          'start', 'created', 'first_byte', 'end']
                 for request in requests:
+                    # Only take the timing from the first remaining request and skip others
+                    # TODO (AD) Review as this timing point should really be NavigationStart
+                    if self.start_time != None:
+                        continue
                     for time_name in times:
                         if time_name in request and self.marked_start_time is None:
                             if self.start_time is None or request[time_name] < self.start_time:


### PR DESCRIPTION
Start time is calculated as the earliest of `dns_start, dns_end, connect_start, connect_end, ssl_start, ssl_end, start, created, first_byte, end` across all requests

But, if Chrome does a DNS lookup for www.google.com before Navigation Start and the page has a resource from google.com in it then start_time can be too early leading to a mismatch between the netlog data and other Chrome data

This PR changes the code so only the times from the `first` request are considered when calculating start time