### PR TITLE
Chrome flags and docker updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -117,7 +117,7 @@ COPY ./docker/linux-headless/entrypoint.sh /wptagent/entrypoint.sh
 
 WORKDIR /wptagent
 
-HEALTHCHECK --interval=600s --timeout=30s --start-period=30s \
+HEALTHCHECK --interval=300s --timeout=30s --start-period=30s \
   CMD curl -f http://localhost:8888/ping || exit 1
 
 CMD ["/bin/bash", "/wptagent/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ LABEL author="support@speedcurve.com"
 #
 ARG CHROME_STABLE_VERSION=107.0.5304.87-1
 ARG FIREFOX_STABLE_VERSION=105.0
-ARG LIGHTHOUSE_VERSION=9.6.7
+ARG LIGHTHOUSE_VERSION=10.1.0
 ARG NODEJS_VERSION=16.x
 
 # Default Timeszone
@@ -20,7 +20,7 @@ ARG NODEJS_VERSION=16.x
 # TODO Is there are better way to do this as most customers won't be in this tz?
 # Maybe just keep it as UTC?
 #
-ENV TZ=Europe/London
+ENV TZ=UTC
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
 RUN apt-get update && \
@@ -118,3 +118,7 @@ COPY ./docker/linux-headless/entrypoint.sh /wptagent/entrypoint.sh
 WORKDIR /wptagent
 
 CMD ["/bin/bash", "/wptagent/entrypoint.sh"]
+
+HEALTHCHECK --interval=600s --timeout=30s --start-period=30s \
+  CMD curl -f http://localhost:8888/ping || exit 1
+  

--- a/Dockerfile
+++ b/Dockerfile
@@ -117,8 +117,9 @@ COPY ./docker/linux-headless/entrypoint.sh /wptagent/entrypoint.sh
 
 WORKDIR /wptagent
 
-CMD ["/bin/bash", "/wptagent/entrypoint.sh"]
-
 HEALTHCHECK --interval=600s --timeout=30s --start-period=30s \
   CMD curl -f http://localhost:8888/ping || exit 1
+
+CMD ["/bin/bash", "/wptagent/entrypoint.sh"]
+
   

--- a/internal/chrome_desktop.py
+++ b/internal/chrome_desktop.py
@@ -47,8 +47,8 @@ else:
 CHROME_COMMAND_LINE_OPTIONS = [
     '--allow-running-insecure-content',
     '--enable-automation',
-    '--disable-back-forward-cache',
     '--disable-background-networking',
+    '--disable-backgrounding-occluded-windows',
     '--disable-background-timer-throttling',
     '--disable-breakpad',
     '--disable-client-side-phishing-detection',


### PR DESCRIPTION
Chrome Agent
- Enabled bfcache (mainly to prevent Lighthouse warning)
- Stopped occluded windows being treated as background ones (shouldn't change our tests)

Docker
- Updated to LH 10
- Use UTC timezone
- Add healthcheck response