### PR TITLE
Update setHeader to use DevTools Fetch methods

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -111,6 +111,7 @@ RUN apt-get update && \
 
 COPY ./wptagent.py /wptagent/wptagent.py
 COPY ./internal /wptagent/internal
+COPY ./urlmatch /wptagent/urlmatch
 COPY ./ws4py /wptagent/ws4py
 
 COPY ./docker/linux-headless/entrypoint.sh /wptagent/entrypoint.sh

--- a/docs/HowtheAgentWorks.md
+++ b/docs/HowtheAgentWorks.md
@@ -1,0 +1,80 @@
+# How the Agent Works
+This currently focuses on how the Chrome Agent works, although the other browsers work in a similar way there are some differences
+
+It's also a work in progress!
+
+Agent is divided into three main parts
+- Poll the server for jobs
+- Execute the jobs it gets – launch browser, execute scripts, gather data as script executes
+- Process the data it gathers and send it to the server
+
+## Polling the Server 
+
+## Executing the Job
+
+## Processing the Data
+
+In Chrome, there are three sources of used to generate the  'result'
+- Chrome Debugger Protocol (CDP) Events
+- TimeLine Events (as seen if you export a trace from Chrome's Performance Panel)
+- NetLog Events 
+
+These are processed by
+- `internal/support/devtools_parser.py`
+- `internal/support/trace_parser.py`
+- `internal/support/netlog_parser.py`
+
+Each of these can be run as standalone CLI tools - see the code for the list of arguments
+
+
+
+## Notes
+
+### setHeader
+
+When headers are set via CDPs `[Network.setExtraHeaders](https://chromedevtools.github.io/devtools-protocol/tot/Network/#method-setExtraHTTPHeaders)` command then they are added to all outgoing requests, and this can create CORS issues.
+
+CDPs `[Fetch Domain](https://chromedevtools.github.io/devtools-protocol/tot/Fetch/)` enables individual request interception based on a urlpattern.
+
+`[Fetch.enable](https://chromedevtools.github.io/devtools-protocol/tot/Fetch/#method-enable)` intialises interception. When a pattern matches a `[Fetch.requestPaused](https://chromedevtools.github.io/devtools-protocol/tot/Fetch/#event-requestPaused)` event is sent to the agent for it to add headers. The agent then responds with`[Fetch.continueRequest](https://chromedevtools.github.io/devtools-protocol/tot/Fetch/#method-continueRequest)`. 
+
+**If the agent doesn't respond to the Fetch.requestPaused event the test will hang until it times out**
+
+This flow is implemented in the agent via
+
+#### devtools.py:set_header
+
+For each new header set and entry is added to `additional_headers` and `Fetch.enable` called.
+
+The additional headers array follow this format
+
+``` json
+[{
+    'pattern': urlpattern, 
+    'header': {
+        'name': name, 
+        'value': value
+    }
+}]
+```
+
+If there's no pattern specified in the setHeader command then a default pattern of *://*/* is applied. This should perhaps default to the origin of the page being tested instead
+
+#### devtools.py:reset_headers
+
+Empties the `additional_headers' array and calls `Fetch.disable`.
+
+If request interception is extended to other uses e.g. authentication then this code will need reviewing. Perhaps it should empty the array and then call `Fetch.enable` with the empty array?
+
+
+#### devtools.py:process_fetch_event
+
+This processes the `Fetch.requestPaused` events. When one is recieved it compares the URL of the request with the patterns in the `additional_header` array, and when there's a match responds with the appropriate headers.
+
+To avoid the test hanging the error handling attempts to always return a response even if it's an empty array.
+
+Comparisons between the URL and the URL Pattern are made using [urlmatch](https://github.com/jessepollak/urlmatch). This module doesn't support unicode strings so the strings are forced to non unicode which may present issues and should be revisited in the future.
+
+*://*/* will match all requests
+https://*.speedcurve.com/* will match all requests to https://www.speedcurve.com, https://app.speedcurve.com etc
+https://www.speedcurve.com will only match request to https://www.speedcurve.com/ and won't match https://www.speedcurve.com/some-path 

--- a/docs/HowtheAgentWorks.md
+++ b/docs/HowtheAgentWorks.md
@@ -58,7 +58,7 @@ The additional headers array follow this format
 }]
 ```
 
-If there's no pattern specified in the setHeader command then a default pattern of *://*/* is applied. This should perhaps default to the origin of the page being tested instead
+If there's no pattern specified in the setHeader command then a default pattern of *://*/* is applied. This should perhaps default to the origin of the page being tested instead.
 
 #### devtools.py:reset_headers
 
@@ -75,6 +75,6 @@ To avoid the test hanging the error handling attempts to always return a respons
 
 Comparisons between the URL and the URL Pattern are made using [urlmatch](https://github.com/jessepollak/urlmatch). This module doesn't support unicode strings so the strings are forced to non unicode which may present issues and should be revisited in the future.
 
-*://*/* will match all requests
-https://*.speedcurve.com/* will match all requests to https://www.speedcurve.com, https://app.speedcurve.com etc
-https://www.speedcurve.com will only match request to https://www.speedcurve.com/ and won't match https://www.speedcurve.com/some-path 
+`*://*/*` will match all requests
+`https://*.speedcurve.com/*` will match all requests to https://www.speedcurve.com, https://app.speedcurve.com etc
+`https://www.speedcurve.com` will only match request to https://www.speedcurve.com/ and won't match https://www.speedcurve.com/some-path 

--- a/internal/devtools.py
+++ b/internal/devtools.py
@@ -256,6 +256,7 @@ class DevTools(object):
                 self.send_command('Profiler.enable', {})
                 self.send_command('Profiler.setSamplingInterval', {'interval': 100})
                 self.send_command('Profiler.start', {})
+
             trace_config = {"recordMode": "recordAsMuchAsPossible",
                             "includedCategories": []}
             if 'trace' in self.job and self.job['trace']:
@@ -266,7 +267,6 @@ class DevTools(object):
                         if category.find("*") < 0 and category not in trace_config["includedCategories"]:
                             trace_config["includedCategories"].append(category)
                 else:
-                    # TODO(AD) - review the impact of the cdp categories on test performance
                     trace_config["includedCategories"] = [
                         "toplevel",
                         "blink",
@@ -274,9 +274,7 @@ class DevTools(object):
                         "cc",
                         "gpu",
                         "blink.net",
-                        "disabled-by-default-v8.runtime_stats",
-                        "disabled-by-default-cc.debug.cdp-perf",
-                        "cdp.perf"]
+                        "disabled-by-default-v8.runtime_stats"]
             else:
                 self.job['keep_netlog'] = False
             if 'netlog' in self.job and self.job['netlog']:
@@ -312,6 +310,14 @@ class DevTools(object):
                 trace_config["includedCategories"].append("netlog")
             if "disabled-by-default-netlog" not in trace_config["includedCategories"]:
                 trace_config["includedCategories"].append("disabled-by-default-netlog")
+
+            # Track how long CDP Fetch requests get paused for
+            # TODO(AD) - review the impact of the cdp categories on test performance
+            if "disabled-by-default-cc.debug.cdp-perf" not in trace_config["includedCategories"]:
+                trace_config["includedCategories"].append("disabled-by-default-cc.debug.cdp-perf")
+            if "cdp.perf" not in trace_config["includedCategories"]:
+                trace_config["includedCategories"].append("cdp.perf")
+
             self.trace_enabled = True
             self.send_command('Tracing.start',
                               {'traceConfig': trace_config},
@@ -910,7 +916,7 @@ class DevTools(object):
     def reset_headers(self):
         """Stop modifying headers on the outbound requests"""
 
-        self.additional_headers = {}
+        self.additional_headers = []
         # This will need moving if we start supporting auth via Fetch
         self.send_command('Fetch.disable', wait=True)
 

--- a/internal/devtools_browser.py
+++ b/internal/devtools_browser.py
@@ -493,7 +493,8 @@ class DevtoolsBrowser(object):
                     needs_mark = False
                 script = self.prepare_script_for_record(script, needs_mark) #pylint: disable=no-member
                 self.devtools.start_navigating()
-            self.devtools.execute_js(script)
+            result = self.devtools.execute_js(script)
+            logging.debug(result)
         elif command['command'] == 'sleep':
             delay = min(60, max(0, int(re.search(r'\d+', str(command['target'])).group())))
             if delay > 0:
@@ -543,9 +544,9 @@ class DevtoolsBrowser(object):
             except Exception:
                 logging.exception('Error setting location')
         elif command['command'] == 'addheader':
-            self.devtools.set_header(command['target'])
+            self.devtools.set_header(command['target'], command['value'])
         elif command['command'] == 'setheader':
-            self.devtools.set_header(command['target'])
+            self.devtools.set_header(command['target'], command['value'])
         elif command['command'] == 'resetheaders':
             self.devtools.reset_headers()
         elif command['command'] == 'clearcache':

--- a/internal/webpagetest.py
+++ b/internal/webpagetest.py
@@ -701,6 +701,7 @@ class WebPageTest(object):
                         job['url'] = target
                         record = True
                     elif command == 'addheader' or command == 'setheader':
+                        # AD - Think these are collected here to be passed to the LH test
                         if target is not None and len(target):
                             separator = target.find(':')
                             if separator > 0:

--- a/urlmatch/LICENSE.md
+++ b/urlmatch/LICENSE.md
@@ -1,0 +1,13 @@
+Copyright 2014 Jesse Pollak.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/urlmatch/__init__.py
+++ b/urlmatch/__init__.py
@@ -1,0 +1,1 @@
+from .urlmatch import urlmatch, BadMatchPattern

--- a/urlmatch/urlmatch.py
+++ b/urlmatch/urlmatch.py
@@ -1,0 +1,86 @@
+"""
+urlmatch lets you easily check whether urls are on a domain or subdomain
+"""
+import re
+
+
+class BadMatchPattern(Exception):
+    """The Exception that's raised when a match pattern fails"""
+    pass
+
+
+def parse_match_pattern(pattern, path_required=True, fuzzy_scheme=False,
+                        http_auth_allowed=True):
+    """
+    Returns the regular expression for a given match pattern.
+
+    Args:
+        pattern: a `urlmatch` formatted match pattern
+        path_required: a `bool` which dicates whether the match pattern
+            must have path
+        fuzzy_scheme: if this is true, then if the scheme is `*`, `http`,
+            or `https`, it will match both `http` and `https`
+        http_auth_allowed: if this is true, then URLs with http auth on the
+            correct domain and path will be matched
+
+    Returns:
+        a regular expresion for the match pattern
+    """
+    pattern_regex = "(?:^"
+    result = re.search(r'^(\*|https?):\/\/', pattern)
+    if not result:
+        raise BadMatchPattern("Invalid scheme: {}".format(pattern))
+    elif result.group(1) == "*" or fuzzy_scheme:
+        pattern_regex += "https?"
+    else:
+        pattern_regex += result.group(1)
+
+    pattern_regex += "://"
+
+    if http_auth_allowed:
+        # add optional HTTP auth
+        safe_characters = r"[^\/:.]"
+        pattern_regex += r"(?:{safe}+(?:\:{safe}+)?@)?".format(
+            safe=safe_characters)
+
+    pattern = pattern[len(result.group(0)):]
+
+    domain_and_path_regex = r'^(?:\*|(\*\.)?([^\/*]+))'
+    if path_required:
+        domain_and_path_regex += r'(?=\/)'
+
+    result = re.search(domain_and_path_regex, pattern)
+    if not result:
+        raise BadMatchPattern("Invalid domain or path: {}".format(pattern))
+
+    pattern = pattern[len(result.group(0)):]
+
+    if result.group(0) == "*":
+        pattern_regex += "[^/]+"
+    else:
+        if result.group(1):
+            pattern_regex += "(?:[^/]+\\.)?"
+
+        pattern_regex += re.escape(result.group(2))
+
+    pattern_regex += ".*".join(map(re.escape, pattern.split("*")))
+    pattern_regex += r'(\/.*)?$)'
+
+    return pattern_regex
+
+
+def urlmatch(match_pattern, url, **kwargs):
+    """
+    Returns whether a given match pattern matches a url
+
+    Args:
+        match_pattern: a `urlmatch` formatted match pattern_regex
+        url: a url
+    """
+
+    if isinstance(match_pattern, str):
+        match_pattern = map(str.strip, match_pattern.split(','))
+
+    regex = "({})".format("|".join(map(lambda x: parse_match_pattern(x, **kwargs), match_pattern)))
+
+    return bool(regex and re.search(regex, url))


### PR DESCRIPTION
Current implementation of setHeader uses DevTools setExtraHeaders method. This applies the header to all requests and can result in CORS issues.

PR switches to using the DevTools Fetch methods, and allows the headers to be applied to specific URL patterns only