### PR TITLE
add injectScript command (Chrome only)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -112,6 +112,7 @@ RUN apt-get update && \
 COPY ./wptagent.py /wptagent/wptagent.py
 COPY ./internal /wptagent/internal
 COPY ./ws4py /wptagent/ws4py
+COPY ./urlmatch /wptagent/urlmatch
 
 COPY ./docker/linux-headless/entrypoint.sh /wptagent/entrypoint.sh
 

--- a/internal/devtools_browser.py
+++ b/internal/devtools_browser.py
@@ -556,6 +556,8 @@ class DevtoolsBrowser(object):
                                  int(re.search(r'\d+',
                                                str(command['target'])).group()) == 1)
             self.devtools.disable_cache(disable_cache)
+        elif command['command'] == 'injectscript':
+            self.devtools.add_post_navigation_script(command['target'])
 
     def navigate(self, url):
         """Navigate to the given URL"""


### PR DESCRIPTION
Adds the `injectScript` command

This command injects a script into the page being tested shortly after Chrome starts building the DOM for the page

Chrome only at the moment as Firefox executes the script much later