### PR TITLE
Adds support for injectScript command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -112,6 +112,7 @@ RUN apt-get update && \
 COPY ./wptagent.py /wptagent/wptagent.py
 COPY ./internal /wptagent/internal
 COPY ./ws4py /wptagent/ws4py
+COPY ./urlmatch /wptagent/urlmatch
 
 COPY ./docker/linux-headless/entrypoint.sh /wptagent/entrypoint.sh
 

--- a/internal/devtools_browser.py
+++ b/internal/devtools_browser.py
@@ -556,6 +556,8 @@ class DevtoolsBrowser(object):
                                  int(re.search(r'\d+',
                                                str(command['target'])).group()) == 1)
             self.devtools.disable_cache(disable_cache)
+        elif command['command'] == 'injectscript':
+            self.devtools.add_post_navigation_script(command['target'])
 
     def navigate(self, url):
         """Navigate to the given URL"""

--- a/internal/devtools_browser.py
+++ b/internal/devtools_browser.py
@@ -493,7 +493,8 @@ class DevtoolsBrowser(object):
                     needs_mark = False
                 script = self.prepare_script_for_record(script, needs_mark) #pylint: disable=no-member
                 self.devtools.start_navigating()
-            self.devtools.execute_js(script)
+            result = self.devtools.execute_js(script)
+            logging.debug(result)
         elif command['command'] == 'sleep':
             delay = min(60, max(0, int(re.search(r'\d+', str(command['target'])).group())))
             if delay > 0:
@@ -543,9 +544,9 @@ class DevtoolsBrowser(object):
             except Exception:
                 logging.exception('Error setting location')
         elif command['command'] == 'addheader':
-            self.devtools.set_header(command['target'])
+            self.devtools.set_header(command['target'], command['value'])
         elif command['command'] == 'setheader':
-            self.devtools.set_header(command['target'])
+            self.devtools.set_header(command['target'], command['value'])
         elif command['command'] == 'resetheaders':
             self.devtools.reset_headers()
         elif command['command'] == 'clearcache':

--- a/internal/webpagetest.py
+++ b/internal/webpagetest.py
@@ -127,7 +127,7 @@ class WebPageTest(object):
                 pass
         # If we are running in a git clone, grab the date of the last
         # commit as the version
-        self.version = '20.06'
+        self.version = '23.09'
         try:
             directory = os.path.abspath(os.path.dirname(__file__))
             if (sys.version_info >= (3, 0)):


### PR DESCRIPTION
Chrome only ATM

injectScript command injects a script into the page that's executed shortly after the page starts navigating

Scripts are executed in order

This script injects two scripts that blur p and h1 elements on the features/performance-monitoring page

```
navigate	%URL%

injectscript	(function () { style = document.createElement('style'); style.innerHTML = "h1 {filter: blur(5px) !important}"; document.head.appendChild(style); })();
injectscript	(function () { style = document.createElement('style'); style.innerHTML = "p {filter: blur(5px) !important}"; document.head.appendChild(style); })();

navigate	%ORIGIN%/features/performance-monitoring/

navigate	%ORIGIN%/features/core-web-vitals/
```

Chrome only ATM as the Firefox equivalent executes late in the page load rather than early as in Chrome