### PR TITLE
Add experimental setValueEx script command 

### DIFF
--- a/internal/webpagetest.py
+++ b/internal/webpagetest.py
@@ -849,7 +849,7 @@ class WebPageTest(object):
                                     task['dns_override'].append([target, addr])
                     # Commands that get translated into exec commands
                     elif command in ['click', 'selectvalue', 'sendclick', 'setinnerhtml',
-                                     'setinnertext', 'setvalue', 'submitform']:
+                                     'setinnertext', 'setvalue', 'setvalueex', 'submitform']:
                         if target is not None:
                             # convert the selector into a querySelector
                             separator = target.find('=')
@@ -871,6 +871,13 @@ class WebPageTest(object):
                                     script += '.innerText="{0}";'.format(value.replace('"', '\\"'))
                                 elif command == 'setinnerhtml' and value is not None:
                                     script += '.innerHTML="{0}";'.format(value.replace('"', '\\"'))
+                                elif command == 'setvalueex' and value is not None:
+                                    script = '(function(){el = ' + script + ';'
+                                    script += 'proto = Object.getPrototypeOf(el); set = Object.getOwnPropertyDescriptor(proto, "value").set;'
+                                    script += 'set.call(el, "{0}");'.format(value.replace('"', '\\"'))
+                                    script += 'el.dispatchEvent(new Event("input", { bubbles: true }));'
+                                    script += 'el.dispatchEvent(new Event("change", { bubbles: true }));'
+                                    script += '})();'
                                 command = 'exec'
                                 target = script
                                 value = None


### PR DESCRIPTION
VDOM based frameworks need the input and change events fired when inputs are changed so they can update the VDOM

Currently this leads to code like

```
(function(){el = document.querySelector('[name="username"]');proto = Object.getPrototypeOf(el); set = Object.getOwnPropertyDescriptor(proto, "value").set;set.call(el, "demo");el.dispatchEvent(new Event("input", { bubbles: true }));el.dispatchEvent(new Event("change", { bubbles: true }));})();
```


setValueEx wraps this code into the agent so someone cane just write

```
setValueEx	name=username	demo
```
