### PR TITLE
Update Chrome flags to remove Chrome popups / hints during tests

### DIFF
--- a/internal/chrome_desktop.py
+++ b/internal/chrome_desktop.py
@@ -46,6 +46,7 @@ else:
 
 CHROME_COMMAND_LINE_OPTIONS = [
     '--allow-running-insecure-content',
+    '--ash-no-nudges',
     '--enable-automation',
     '--disable-background-networking',
     '--disable-backgrounding-occluded-windows',
@@ -99,6 +100,7 @@ DISABLE_CHROME_FEATURES = [
     'MediaRouter',
     'OfflinePagesPrefetching',
     'OptimizationHints',
+    'SidePanelPinning',
     'Translate'
 ]
 


### PR DESCRIPTION
Add --ash-no-nudges and disable SidePanelPinning feature to remove Chrome popups during tests