### PR TITLE
Add automatic mobile user-agent transforming for Chromium and Firefox

### DIFF
--- a/internal/devtools_browser.py
+++ b/internal/devtools_browser.py
@@ -169,7 +169,7 @@ class DevtoolsBrowser(object):
             if ua_string is not None and 'auto_mobile_ua' in self.job and self.job['auto_mobile_ua']:
                 # Attempt to automatically convert a desktop user-agent string to mobile
                 ua_string = re.sub(r'(Chrome\/\d+\.\d+\.\d+\.\d+)', r'\1 Mobile', ua_string)
-                ua_string = re.sub(r'Mozilla/5.0 \([^;]+; .+\)', 'Mozilla/5.0 (Linux; Android 10; K)', ua_string)
+                ua_string = re.sub(r'Mozilla/5.0 \([^;]+; .+\)', 'Mozilla/5.0 (Linux; Android 14; K)', ua_string)
             if ua_string is not None:
                 self.job['user_agent_string'] = ua_string
             # Disable js

--- a/internal/devtools_browser.py
+++ b/internal/devtools_browser.py
@@ -161,6 +161,9 @@ class DevtoolsBrowser(object):
                     self.browser_version = match.group(1)
             if 'uastring' in self.job:
                 ua_string = self.job['uastring']
+                if self.browser_version is not None:
+                    # Replace the %BROWSER_VERSION% token with the version in ua_string
+                    ua_string = ua_string.replace('%BROWSER_VERSION%', self.browser_version)
             if ua_string is not None and 'AppendUA' in task:
                 ua_string += ' ' + task['AppendUA']
             if 'auto_mobile_ua' in self.job and self.job['auto_mobile_ua']:

--- a/internal/devtools_browser.py
+++ b/internal/devtools_browser.py
@@ -163,6 +163,9 @@ class DevtoolsBrowser(object):
                 ua_string = self.job['uastring']
             if ua_string is not None and 'AppendUA' in task:
                 ua_string += ' ' + task['AppendUA']
+            if 'auto_mobile_ua' in self.job and self.job['auto_mobile_ua']:
+                # Attempt to automatically convert a desktop user-agent string to mobile
+                ua_string = re.sub(r'(Chrome\/\d+\.\d+\.\d+\.\d+)', r'\1 Mobile', ua_string)
             if ua_string is not None:
                 self.job['user_agent_string'] = ua_string
             # Disable js

--- a/internal/devtools_browser.py
+++ b/internal/devtools_browser.py
@@ -166,7 +166,7 @@ class DevtoolsBrowser(object):
                     ua_string = ua_string.replace('%BROWSER_VERSION%', self.browser_version)
             if ua_string is not None and 'AppendUA' in task:
                 ua_string += ' ' + task['AppendUA']
-            if 'auto_mobile_ua' in self.job and self.job['auto_mobile_ua']:
+            if ua_string is not None and 'auto_mobile_ua' in self.job and self.job['auto_mobile_ua']:
                 # Attempt to automatically convert a desktop user-agent string to mobile
                 ua_string = re.sub(r'(Chrome\/\d+\.\d+\.\d+\.\d+)', r'\1 Mobile', ua_string)
                 ua_string = re.sub(r'Mozilla/5.0 \([^;]+; .+\)', 'Mozilla/5.0 (Linux; Android 10; K)', ua_string)

--- a/internal/devtools_browser.py
+++ b/internal/devtools_browser.py
@@ -161,14 +161,15 @@ class DevtoolsBrowser(object):
                     self.browser_version = match.group(1)
             if 'uastring' in self.job:
                 ua_string = self.job['uastring']
+                # Replace the %BROWSER_VERSION% token with the version in ua_string
                 if self.browser_version is not None:
-                    # Replace the %BROWSER_VERSION% token with the version in ua_string
                     ua_string = ua_string.replace('%BROWSER_VERSION%', self.browser_version)
             if ua_string is not None and 'AppendUA' in task:
                 ua_string += ' ' + task['AppendUA']
             if 'auto_mobile_ua' in self.job and self.job['auto_mobile_ua']:
                 # Attempt to automatically convert a desktop user-agent string to mobile
                 ua_string = re.sub(r'(Chrome\/\d+\.\d+\.\d+\.\d+)', r'\1 Mobile', ua_string)
+                ua_string = re.sub(r'Mozilla/5.0 \([^;]+; .+\)', 'Mozilla/5.0 (Linux; Android 10; K)', ua_string)
             if ua_string is not None:
                 self.job['user_agent_string'] = ua_string
             # Disable js

--- a/internal/firefox.py
+++ b/internal/firefox.py
@@ -184,6 +184,9 @@ class Firefox(DesktopBrowser):
                 modified = False
                 if 'uastring' in self.job:
                     ua_string = self.job['uastring']
+                    # Replace the %BROWSER_VERSION% token with the version in ua_string
+                    if self.browser_version is not None:
+                        ua_string = ua_string.replace('%BROWSER_VERSION%', self.browser_version)
                     modified = True
                 if ua_string is not None and 'AppendUA' in task:
                     ua_string += ' ' + task['AppendUA']

--- a/internal/firefox.py
+++ b/internal/firefox.py
@@ -193,7 +193,6 @@ class Firefox(DesktopBrowser):
                     modified = True
                 if ua_string is not None and 'auto_mobile_ua' in self.job and self.job['auto_mobile_ua']:
                     # Attempt to automatically convert a desktop user-agent string to mobile
-                    # Replace rv:\d with Mobile; rv:\d
                     ua_string = re.sub(r'\(.+(rv:\d+)(.+)\)', r'(Android 14; Mobile; \1\2)', ua_string)
                     modified = True
                 if modified:

--- a/internal/firefox.py
+++ b/internal/firefox.py
@@ -191,7 +191,7 @@ class Firefox(DesktopBrowser):
                 if ua_string is not None and 'AppendUA' in task:
                     ua_string += ' ' + task['AppendUA']
                     modified = True
-                if 'auto_mobile_ua' in self.job and self.job['auto_mobile_ua']:
+                if ua_string is not None and 'auto_mobile_ua' in self.job and self.job['auto_mobile_ua']:
                     # Attempt to automatically convert a desktop user-agent string to mobile
                     # Replace rv:\d with Mobile; rv:\d
                     ua_string = re.sub(r'(rv:\d+)', r'Mobile; \1', ua_string)

--- a/internal/firefox.py
+++ b/internal/firefox.py
@@ -194,7 +194,7 @@ class Firefox(DesktopBrowser):
                 if ua_string is not None and 'auto_mobile_ua' in self.job and self.job['auto_mobile_ua']:
                     # Attempt to automatically convert a desktop user-agent string to mobile
                     # Replace rv:\d with Mobile; rv:\d
-                    ua_string = re.sub(r'(rv:\d+)', r'Mobile; \1', ua_string)
+                    ua_string = re.sub(r'\(.+(rv:\d+)(.+)\)', r'(Android 14; Mobile; \1\2)', ua_string)
                     modified = True
                 if modified:
                     logging.debug(ua_string)

--- a/internal/firefox.py
+++ b/internal/firefox.py
@@ -188,6 +188,11 @@ class Firefox(DesktopBrowser):
                 if ua_string is not None and 'AppendUA' in task:
                     ua_string += ' ' + task['AppendUA']
                     modified = True
+                if 'auto_mobile_ua' in self.job and self.job['auto_mobile_ua']:
+                    # Attempt to automatically convert a desktop user-agent string to mobile
+                    # Replace rv:\d with Mobile; rv:\d
+                    ua_string = re.sub(r'(rv:\d+)', r'Mobile; \1', ua_string)
+                    modified = True
                 if modified:
                     logging.debug(ua_string)
                     self.driver_set_pref('general.useragent.override', ua_string)

--- a/internal/safari_ios.py
+++ b/internal/safari_ios.py
@@ -137,6 +137,9 @@ class iWptBrowser(BaseBrowser):
                     ua_string = self.execute_js('navigator.userAgent;')
                     if 'uastring' in self.job:
                         ua_string = self.job['uastring']
+                        # Replace the %BROWSER_VERSION% token with the version in ua_string
+                        if self.browser_version is not None:
+                            ua_string = ua_string.replace('%BROWSER_VERSION%', self.browser_version)
                     if ua_string is not None and 'AppendUA' in task:
                         ua_string += ' ' + task['AppendUA']
                     if ua_string is not None:


### PR DESCRIPTION
This PR adds a new `auto_mobile_ua` job param that attempts to automatically transform a user-agent string into the mobile version of that string.