### PR TITLE
Add setLanguage script command for Chrome. Improve netlog exception handling.

### DIFF
--- a/internal/chrome_desktop.py
+++ b/internal/chrome_desktop.py
@@ -137,6 +137,8 @@ class ChromeDesktop(DesktopBrowser, DevtoolsBrowser):
         args.append('--remote-allow-origins=*')
         if 'ignoreSSL' in job and job['ignoreSSL']:
             args.append('--ignore-certificate-errors')
+        if 'language' in task and task['language'] is not None:
+            args.append('--accept-lang=' + task['language'])
 
     # TODO (AD) Review
 

--- a/internal/support/netlog_parser.py
+++ b/internal/support/netlog_parser.py
@@ -476,7 +476,10 @@ class NetLogParser():
                     else:
                         found1stRequest = True
                 for to_remove in requests_to_remove:
-                    requests.pop(to_remove)
+                    try:
+                        requests.pop(to_remove)
+                    except Exception as err:
+                        logging.exception('Error removing request %d from requests: %s', to_remove, err)
 
                 # Find the start timestamp if we didn't have one already
                 times = ['dns_start', 'dns_end',

--- a/internal/webpagetest.py
+++ b/internal/webpagetest.py
@@ -578,7 +578,8 @@ class WebPageTest(object):
                         'navigated': False,
                         'page_result': None,
                         'script_step_count': 1,
-                        'naive_navigation_count' : 1
+                        'naive_navigation_count' : 1,
+                        'language': None
                     }
                 # Increase the activity timeout for high-latency tests
                 if 'latency' in job:
@@ -870,6 +871,10 @@ class WebPageTest(object):
                                 if re.match(r'^\d+\.\d+\.\d+\.\d+$', addr) and \
                                         re.match(r'^[a-zA-Z0-9\-\.]+$', target):
                                     task['dns_override'].append([target, addr])
+                    elif command == 'setlanguage':
+                        # Set browser language
+                        if target is not None:
+                            task['language'] = target
                     # Commands that get translated into exec commands
                     elif command in ['click', 'selectvalue', 'sendclick', 'setinnerhtml',
                                      'setinnertext', 'setvalue', 'setvalueex', 'setotpvalue', 'submitform']:


### PR DESCRIPTION
Add setLanguage script command for Chrome to allow customers to specify the accept-language header and navigator.language. 
Add exception handling in netlog parser to solve a customer issue