### PR TITLE
Start recording netlog after tracing data to avoid tracing data startup time

### DIFF
--- a/internal/chrome_desktop.py
+++ b/internal/chrome_desktop.py
@@ -74,7 +74,8 @@ HOST_RULES = [
     '"MAP optimizationguide-pa.googleapis.com 127.0.0.1"',
     '"MAP offlinepages-pa.googleapis.com 127.0.0.1"',
     '"MAP update.googleapis.com 127.0.0.1"',
-    '"MAP content-autofill.googleapis.com 127.0.0.1"'
+    '"MAP content-autofill.googleapis.com 127.0.0.1"',
+    '"MAP android.clients.google.com 127.0.0.1"'
 ]
 
 ENABLE_CHROME_FEATURES = [
@@ -120,6 +121,7 @@ class ChromeDesktop(DesktopBrowser, DevtoolsBrowser):
         self.netlog_lock = threading.Lock()
         self.netlog_thread = None
         self.netlog = None
+        self.keep_netlogs = False
 
     def launch(self, job, task):
         """Launch the browser"""
@@ -144,7 +146,7 @@ class ChromeDesktop(DesktopBrowser, DevtoolsBrowser):
 
         streamed_netlog = False
 
-        # TODO (AD) Can I just wrap this in a task['running_lighthouse'] is False check?
+        # Only capture netlog for non-Lighthouse runs
         if task['running_lighthouse'] is False:
             if platform.system() in ["Linux", "Darwin"]:
                 self.netlog_pipe = os.path.join(task['dir'], 'netlog.pipe')
@@ -164,13 +166,14 @@ class ChromeDesktop(DesktopBrowser, DevtoolsBrowser):
                     logging.exception('Error creating pipe for NetLog')
 
             # If we need to keep the netlog create file to write it to
-            # TODO (AD) Stop doing this for lighthouse runs
             if 'netlog' in job and job['netlog']:
-                self.netlog_file = os.path.join(task['dir'], task['prefix']) + '_netlog.txt'
-                self.netlog_out = open(self.netlog_file, 'wt')
+                self.keep_netlogs = True
 
-                if not streamed_netlog:
-                    args.append('--log-net-log="{0}"'.format(self.netlog_file))
+#                self.netlog_file = os.path.join(task['dir'], task['prefix']) + '_netlog.txt'
+#                self.netlog_out = open(self.netlog_file, 'wt')
+
+#                if not streamed_netlog:
+#                    args.append('--log-net-log="{0}"'.format(self.netlog_file))
 
         if 'profile' in task:
             args.append('--user-data-dir="{0}"'.format(task['profile']))
@@ -260,11 +263,6 @@ class ChromeDesktop(DesktopBrowser, DevtoolsBrowser):
 # TODO (AD) This is a variation of the code in netlog_parser, is it possible to merge them?
             processing_events = False
             for line in self.netlog_in:
-
-                # Save a copy of the netlog if we need to
-                with self.netlog_lock:
-                    if self.netlog_out:
-                        self.netlog_out.write(line)
 
                 try:
                     line = line.strip(', \r\n')
@@ -374,12 +372,18 @@ class ChromeDesktop(DesktopBrowser, DevtoolsBrowser):
     def on_start_recording(self, task):
         """Notification that we are about to start an operation that needs to be recorded"""
         DesktopBrowser.on_start_recording(self, task)
+        DevtoolsBrowser.on_start_recording(self, task)
 
         # Remove exisiting requests in NetLog Parser (need to keep constants for parsing future events)
+        # Start recording netlog after tracing has started – starting it before can result in extaneous entries
+        # from the previous step as there's mo guarantee when something sent using sendBeacon will be sent
+        # and the delay in starting tracing can be many seconds e.g. 20s
         with self.netlog_lock:
             self.netlog.clear_requests()
 
-        DevtoolsBrowser.on_start_recording(self, task)
+        if self.keep_netlogs:
+            self.netlog.open_tee(os.path.join(task['dir'], task['prefix']) + '_netlog.txt')
+
 
     def on_stop_capture(self, task):
         """Do any quick work to stop things that are capturing data"""
@@ -392,6 +396,7 @@ class ChromeDesktop(DesktopBrowser, DevtoolsBrowser):
         logging.debug('on_stop_recording')
 
         DesktopBrowser.on_stop_recording(self, task)
+        DevtoolsBrowser.on_stop_recording(self, task)
 
         # Write out the netlog requests for this step
         with self.netlog_lock:
@@ -400,7 +405,8 @@ class ChromeDesktop(DesktopBrowser, DevtoolsBrowser):
                 logging.debug('Writing ' + netlog_requests)
                 self.netlog.write_netlog_requests(netlog_requests)
 
-        DevtoolsBrowser.on_stop_recording(self, task)
+            self.netlog.close_tee()
+
 
     def on_start_processing(self, task):
         """Start any processing of the captured data"""

--- a/internal/devtools_browser.py
+++ b/internal/devtools_browser.py
@@ -193,6 +193,9 @@ class DevtoolsBrowser(object):
         # Save count of total navigations (not just those we're recording)
         task['page_data']['debug']['rawNavigationCount'] = task['naive_navigation_count']
 
+        # Save exec / execAndWait errors - might need some refinement
+        task['page_data']['debug']['errors'] = []
+
         if self.devtools is not None:
             self.devtools.start_recording()
 
@@ -447,6 +450,8 @@ class DevtoolsBrowser(object):
         """Process an individual script command"""
         logging.debug("Processing script command:")
         logging.debug(command)
+
+        # TODO(AD) Update to use match/case
         if command['command'] == 'navigate':
             self.task['page_data']['URL'] = command['target']
             url = str(command['target']).replace('"', '\"')
@@ -491,7 +496,12 @@ class DevtoolsBrowser(object):
                 script = self.prepare_script_for_record(script, needs_mark) #pylint: disable=no-member
                 self.devtools.start_navigating()
             result = self.devtools.execute_js(script)
-            logging.debug(result)
+
+            # TODO(AD) the messaging - probably needs script command and output
+            if result is None:
+                logging.error("Error:" + json.dumps(script))
+                self.task['page_data']['debug']['errors'].append(json.dumps(script))
+
         elif command['command'] == 'sleep':
             delay = min(60, max(0, int(re.search(r'\d+', str(command['target'])).group())))
             if delay > 0:

--- a/internal/support/devtools_parser.py
+++ b/internal/support/devtools_parser.py
@@ -801,6 +801,7 @@ class DevToolsParser(object):
                    'tls_resumed': 'tls_resumed',
                    'tls_next_proto': 'tls_next_proto',
                    'tls_cipher_suite': 'tls_cipher_suite'}
+
         if self.netlog_requests_file is not None and os.path.isfile(self.netlog_requests_file):
             _, ext = os.path.splitext(self.netlog_requests_file)
             if ext.lower() == '.gz':
@@ -809,6 +810,7 @@ class DevToolsParser(object):
                 f_in = open(self.netlog_requests_file, 'r') # TODO (AD) Should this be rt?
             netlog = json.load(f_in)
             f_in.close()
+
             keep_requests = []
             for request in requests:
                 if 'request_id' not in request and 'id' in request:
@@ -846,8 +848,6 @@ class DevToolsParser(object):
                             if 'end' in entry:
                                 request['load_ms'] = int(round(entry['end'] -
                                                                entry['start']))
-                            if 'pushed' in entry and entry['pushed']:
-                                request['was_pushed'] = 1
                             if 'request_headers' in entry:
                                 if 'headers' not in request:
                                     request['headers'] = {'request': [], 'response': []}
@@ -1421,7 +1421,6 @@ def main():
     parser.add_argument('-o', '--out', help="Output requests json file.")
     options, _ = parser.parse_known_args()
 
-    # Set up logging
     # Set up logging
     log_level = logging.CRITICAL
   

--- a/internal/support/netlog_parser.py
+++ b/internal/support/netlog_parser.py
@@ -50,7 +50,9 @@ class NetLogParser():
         self.marked_start_time = None # TODO (AD) Unused ???
         self.netlog_requests = None
         self.netlog_event_types = {}
+        self.raw_constants = {}
         self.constants = {}
+        self.netlog_out = None
         return
 
     def clear_requests(self):
@@ -60,7 +62,24 @@ class NetLogParser():
         self.marked_start_time = None
         self.netlog_requests = None
         self.netlog_event_types = {}
+        self.netlog_out = None
 
+    def open_tee(self, out_file):
+        """ Retain per-step raw netlog data for debugging etc"""
+        if self.netlog_out is None:
+            self.netlog_out = open(out_file, 'wt')
+
+        # Constants are re-used from step to step so write out any constants captured in first step
+        if self.constants:
+            self.netlog_out.write('{"constants":' + json.dumps(self.raw_constants) + ',\n "events": [\n')
+
+
+    def close_tee(self):
+        """ Close the raw netlog file """
+        if self.netlog_out is not None:
+            self.netlog_out.write(']}\n')
+            self.netlog_out.close()
+            self.netlog_out = None
 #
 # process_netlog
 #
@@ -118,6 +137,10 @@ class NetLogParser():
 #
     def process_constants(self, constants):
         """ Create lookup table from constants entry in NetLog """
+
+        # Store the unmodified constants for output if needed
+        self.raw_constants = constants
+
         for entry in constants:
             # Exclude entries such as "activeFieldTrialGroups":[] that aren't dictionaries
             if isinstance(constants[entry], dict):
@@ -125,6 +148,7 @@ class NetLogParser():
                 for key in constants[entry]:
                     value = constants[entry][key]
                     self.constants[entry][value] = key
+
 
 # 
 # process_event
@@ -144,6 +168,10 @@ class NetLogParser():
     def process_event(self, event):
 
         try:
+
+            if self.netlog_out is not None:
+                self.netlog_out.write(json.dumps(event) + ',\n')
+
             if 'phase' in event:
                 event['phase'] = self.constants['logEventPhase'][event['phase']]
             if 'type' in event:
@@ -161,6 +189,7 @@ class NetLogParser():
                 event['time'] = int(event['time']) * 1000
 
             self.ProcessNetlogEvent(event)
+
         except Exception as error: 
             logging.exception(error)
         
@@ -183,7 +212,7 @@ class NetLogParser():
 #                elif name in self.netlog_event_types:
 #                    event_type = self.netlog_event_types[name]
                 
-                event_type=event['source']['name'] # TODO (AD) switch to type?
+                event_type = event['source']['name'] # TODO (AD) switch to type?
 
                 if event_type is not None:
                     if event_type == 'HOST_RESOLVER_IMPL_JOB' or \
@@ -724,7 +753,7 @@ class NetLogParser():
                 self.netlog['connect_job'][parent_id]['dns'] = request_id
 #        if name == 'HOST_RESOLVER_SYSTEM_TASK' and 'phase' in event:
 # https://source.chromium.org/chromium/chromium/src/+/main:net/log/net_log_event_type_list.h;bpv=1;bpt=0;drc=9600a6c5b3ec6ab79b621b873cc95252512f310a;dlc=6c74820452efb7bf001b84cec2e38d5956f5f2a2
-        if name == 'HOST_RESOLVER_MANAGER_REQUEST' and 'phase' in event:
+        if (name == 'HOST_RESOLVER_MANAGER_REQUEST' or name == 'HOST_RESOLVER_DNS_TASK') and 'phase' in event:
             if event['phase'] == 'PHASE_BEGIN':
                 if 'start' not in entry or event['time'] < entry['start']: # entry['source']['start']:
                     entry['start'] = event['time']


### PR DESCRIPTION
Also 
- remove support for HTTP2 push
- block requests to android.clients.google.com
- add some recording of exec / execAndWait errors 
- create individual netlogs per step when netlog is requested